### PR TITLE
Feat/npx sdef to dfs

### DIFF
--- a/packages/@jxa/sdef-to-dts/README.md
+++ b/packages/@jxa/sdef-to-dts/README.md
@@ -8,7 +8,7 @@ Install with [npm](https://www.npmjs.com/):
 
     npm install @jxa/sdef-to-dts
 
-## Usage
+## Usage as library
 
 Convert `./input/*.sdef` file and output it as `d.ts` to `./output` directory.
 
@@ -29,6 +29,19 @@ const promises = fs.readdirSync(sdefDir).map(async caseName => {
 Promise.all(promises).then(() => {
     console.log("All write");
 });
+```
+
+## Usage as command
+
+Convert application bundles (e.g. `/Applications/Safari.app`) and output as `d.ts`.
+
+```
+Usage: npx @jxa/sdef-to-dts inFile [out]
+
+  Converts Script Definitions into TypeScript Type Definitions
+
+  inFile - path to an Application.app to read"
+  out - path to an Application.d.ts or a directory to write to
 ```
 
 ## Running tests

--- a/packages/@jxa/sdef-to-dts/README.md
+++ b/packages/@jxa/sdef-to-dts/README.md
@@ -36,12 +36,20 @@ Promise.all(promises).then(() => {
 Convert application bundles (e.g. `/Applications/Safari.app`) and output as `d.ts`.
 
 ```
-Usage: npx @jxa/sdef-to-dts inFile [out]
+  Scripting definition files (sdefs) to TypeScript (d.ts)
 
-  Converts Script Definitions into TypeScript Type Definitions
+  Usage
+    $ npx @jxa/sdef-to-dts <input> --output <output>
 
-  inFile - path to an Application.app to read"
-  out - path to an Application.d.ts or a directory to write to
+    <input>       path to an Application.app to read
+
+  Options
+    --output, -o  path to an Application.d.ts or a directory to write to
+    --version     show the version
+    --help        show this help page
+
+  Examples
+    $ npx @jxa/sdef-to-dts /Applications/Safari.app --output ./safari.d.ts
 ```
 
 ## Running tests

--- a/packages/@jxa/sdef-to-dts/bin/cmd.js
+++ b/packages/@jxa/sdef-to-dts/bin/cmd.js
@@ -5,6 +5,7 @@ const path = require("path");
 const child_process = require("child_process");
 const transform = require("../lib/sdef-to-dts").transform;
 const meow = require("meow");
+const execa = require("execa");
 
 const cli = meow(`
         Usage
@@ -63,7 +64,7 @@ function outFile(appName, out) {
 
 function readSdef(path) {
   try {
-    return child_process.execSync("sdef " + path, {stdio: ["ignore"]}).toString();
+    return execa.sync("sdef", [path], {stdio: ["ignore"]}).stdout;
   } catch (e) {
     console.error(e.toString());
     cli.showHelp();

--- a/packages/@jxa/sdef-to-dts/bin/cmd.js
+++ b/packages/@jxa/sdef-to-dts/bin/cmd.js
@@ -11,12 +11,12 @@ const cli = meow(`
         Usage
           $ npx @jxa/sdef-to-dts <input> --output <output>
 
-          <input> - path to an Application.app to read
+          <input>       path to an Application.app to read
 
         Options
-          --output, -o - path to an Application.d.ts or a directory to write to
-          --version    - show the version
-          --help       - show this help page
+          --output, -o  path to an Application.d.ts or a directory to write to
+          --version     show the version
+          --help        show this help page
 
         Examples
           $ npx @jxa/sdef-to-dts /Applications/Safari.app --output ./safari.d.ts

--- a/packages/@jxa/sdef-to-dts/bin/cmd.js
+++ b/packages/@jxa/sdef-to-dts/bin/cmd.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
+const transform = require("../lib/sdef-to-dts").transform;
+
+function usage() {
+  console.log();
+  console.log("Usage: npx @jxa/sdef-to-dts inFile [out]");
+  console.log();
+  console.log("  Converts Script Definitions into TypeScript Type Definitions")
+  console.log();
+  console.log("  inFile - path to an Application.app to read");
+  console.log("  out - path to an Application.d.ts or a directory to write to");
+  console.log();
+}
+
+if (process.argv.length !== 3 && process.argv.length !== 4) {
+  usage();
+  process.exit(1);
+}
+
+const [node, cmd, inFile, out] = process.argv;
+
+run(inFile, out);
+
+function run(inPath, out) {
+  const appName = path.basename(inPath, ".app").replace(/\s/g, "");
+  const outPath = outFile(appName, out);
+
+  const sdef = readSdef(inPath);
+  writeDTS(appName, outPath, sdef)
+    .then(() => {
+      console.log("Converted: " + inPath + " to " + outPath);
+    });
+}
+
+function outFile(appName, out) {
+  if (out) {
+    if (fs.existsSync(out) && fs.lstatSync(out).isDirectory()) {
+      return path.resolve(out, appName) + ".d.ts";
+    } else {
+      return path.resolve(out).replace(/.d.ts$/, "") + ".d.ts";
+    }
+  } else {
+    return path.resolve(appName) + ".d.ts";
+  }
+}
+
+function readSdef(path) {
+  try {
+    return child_process.execSync("sdef " + path, {stdio: ["ignore"]}).toString();
+  } catch (e) {
+    console.error(e.toString());
+    usage();
+    process.exit(2);
+  }
+}
+
+function writeDTS(appName, outPath, sdef) {
+  return transform(appName, sdef).then(content => {
+    fs.writeFileSync(outPath, content, "utf-8");
+  }).catch(err => {
+    console.error(err.toString());
+    usage();
+    process.exit(3);
+  });
+}
+

--- a/packages/@jxa/sdef-to-dts/package.json
+++ b/packages/@jxa/sdef-to-dts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jxa/sdef-to-dts",
   "version": "0.3.1",
-  "description": "Scripting definition files (sdefs) to TypeScript(d.ts)",
+  "description": "Scripting definition files (sdefs) to TypeScript (d.ts)",
   "keywords": [
     "applescript",
     "dts",
@@ -66,6 +66,7 @@
     "indent-string": "^3.2.0",
     "is-keyword": "^1.2.2",
     "is-var-name": "^2.0.0",
-    "json-schema-to-typescript": "^5.4.0"
+    "json-schema-to-typescript": "^5.4.0",
+    "meow": "^5.0.0"
   }
 }

--- a/packages/@jxa/sdef-to-dts/package.json
+++ b/packages/@jxa/sdef-to-dts/package.json
@@ -22,6 +22,7 @@
   ],
   "main": "lib/sdef-to-dts.js",
   "types": "lib/sdef-to-dts.d.ts",
+  "bin": "bin/cmd.js",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/packages/@jxa/sdef-to-dts/package.json
+++ b/packages/@jxa/sdef-to-dts/package.json
@@ -63,6 +63,7 @@
     "@rgrove/parse-xml": "^1.1.1",
     "@types/camelcase": "^4.1.0",
     "camelcase": "^5.0.0",
+    "execa": "^1.0.0",
     "indent-string": "^3.2.0",
     "is-keyword": "^1.2.2",
     "is-var-name": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,7 +539,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.5:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -628,6 +628,12 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -699,6 +705,18 @@ execa@^0.8.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -786,6 +804,12 @@ get-stdin@^4.0.1:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-stream@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.0.0.tgz#9e074cb898bd2b9ebabb445a1766d7f43576d977"
+  dependencies:
+    pump "^3.0.0"
 
 git-raw-commits@^1.3.0, git-raw-commits@^1.3.6:
   version "1.3.6"
@@ -1484,7 +1508,7 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -1646,6 +1670,13 @@ process-nextick-args@~2.0.0:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,20 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -2251,6 +2265,12 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
It turns out that the `sdef` command can be used to generate `.d.ts` files from App bundles. I've made the input parameter to the command the path to the app bundle to allow bundles outside of the `/Applications` folder to be converted too. 

Fixes #7