### PR TITLE
Change method to get environment variable

### DIFF
--- a/packages/@jxa/run/src/run.ts
+++ b/packages/@jxa/run/src/run.ts
@@ -73,8 +73,8 @@ export function run<R, A1, A2, A3, A4, A5, A6, A7, A8, A9>(
 ): Promise<R>;
 export function run(jxaCodeFunction: (...args: any[]) => void, ...args: any[]) {
     const code = `
-ObjC.import('Foundation');
-var args = JSON.parse(ObjC.unwrap($.NSProcessInfo.processInfo.environment.objectForKey("OSA_ARGS")));
+ObjC.import('stdlib');
+var args = JSON.parse($.getenv('OSA_ARGS'));
 var fn   = (${jxaCodeFunction.toString()});
 var out  = fn.apply(null, args);
 JSON.stringify({ result: out });


### PR DESCRIPTION
This pull request changes the method that is used to get the `OSA_ARGS` environment variable.

So far up to macOS Big Sur beta 5 (20A5354i) `$.NSProcessInfo` is undefined, the `$.getenv` method is still available as is used in the [osa2 project](https://github.com/wtfaremyinitials/osa2/blob/master/index.js#L8).