### PR TITLE
fix(types): fix Finder item url definition

### DIFF
--- a/packages/@jxa/types/src/core/Finder.d.ts
+++ b/packages/@jxa/types/src/core/Finder.d.ts
@@ -164,7 +164,7 @@ export namespace Finder {
    /**
     * the URL of the item
     */
-   URL(): string;
+   url(): string;
    /**
     * the user that owns the container
     */

--- a/packages/@jxa/types/tools/sdefs/Finder.sdef
+++ b/packages/@jxa/types/tools/sdefs/Finder.sdef
@@ -155,7 +155,7 @@
 			<property name="creation date" code="ascd" type="date" access="r" description="the date on which the item was created"/>
 			<property name="modification date" code="asmo" type="date" description="the date on which the item was last modified"/>
 			<property name="icon" code="iimg" type="icon family" description="the icon bitmap of the item"/>
-			<property name="URL" code="pURL" type="text" access="r" description="the URL of the item"/>
+			<property name="url" code="purl" type="text" access="r" description="the URL of the item"/>
 			<property name="owner" code="sown" type="text" description="the user that owns the container"/>
 			<property name="group" code="sgrp" type="text" description="the user or group that has special access to the container"/>
 			<property name="owner privileges" code="ownr" type="priv"/>


### PR DESCRIPTION
I wanted to use the type `Finder.Item` in my mapping, but the type defines a `URL` whereas the actual syntax is lowercase.

```
    const files = Application<Finder>('Finder').selection()

    return files.map((f: {kind: () => string; url: () => string}) => ({ kind: f.kind(), path: f.url() }))
```

![Screenshot 2020-10-07 at 10 53 21](https://user-images.githubusercontent.com/10957531/95309984-1f63a600-088c-11eb-8be5-9fbadc0c7445.png)

---
EDIT: Just so you know, I changed the `Finder.sdef` manually. The real one has the key `URL`, but it doesn't work this way:
![Screenshot 2020-10-07 at 11 45 17](https://user-images.githubusercontent.com/10957531/95315394-ba5f7e80-0892-11eb-996a-a54d6c1012c1.png)
